### PR TITLE
configure.ac: removed missing makefiles

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -218,6 +218,5 @@ dnl set proper LDFLAGS for plugins
 GST_PLUGIN_LDFLAGS='-module -avoid-version -export-symbols-regex [_]*\(gst_\|Gst\|GST_\).*'
 AC_SUBST(GST_PLUGIN_LDFLAGS)
 
-AC_CONFIG_FILES([Makefile ext/Makefile ext/erdtls/Makefile gst/Makefile sys/Makefile tests/Makefile tests/icles/Makefile \
-gst/videorepair/Makefile])
+AC_CONFIG_FILES([Makefile ext/Makefile ext/erdtls/Makefile gst/Makefile sys/Makefile gst/videorepair/Makefile])
 AC_OUTPUT


### PR DESCRIPTION
Missing makefiles were causing the build to fail with "missing Makefile.in"
