### PR TITLE
erdtlsenc: Send initial events

### DIFF
--- a/ext/erdtls/src/gsterdtlsenc.h
+++ b/ext/erdtls/src/gsterdtlsenc.h
@@ -59,6 +59,8 @@ struct _GstErDtlsEnc {
     GstBuffer *encoder_key;
     guint srtp_cipher;
     guint srtp_auth;
+
+    gboolean send_initial_events;
 };
 
 struct _GstErDtlsEncClass {


### PR DESCRIPTION
Without a stream-start or segment event before data flow, GStreamer will
complain with g_warnings().
