### PR TITLE
erdtlsenc: start the DTLS handshake timeout after sending the first buffer

### DIFF
--- a/ext/erdtls/src/erdtlsconnection.h
+++ b/ext/erdtls/src/erdtlsconnection.h
@@ -85,6 +85,7 @@ struct _ErDtlsConnectionClass {
 GType er_dtls_connection_get_type(void) G_GNUC_CONST;
 
 void er_dtls_connection_start(ErDtlsConnection *, gboolean is_client);
+void er_dtls_connection_start_timeout(ErDtlsConnection *);
 
 /*
  * Stops the connections, it is not required to call this function.


### PR DESCRIPTION
Start the timeout only after the first buffer has been sent. Previously the timeout was started in READY_TO_PAUSED which was too early.

This is needed to avoid hitting the DTLS timeout and avoid triggering exponential backoff.
