### PR TITLE
Fix build system a bit

### DIFF
--- a/ext/erdtls/Makefile.am
+++ b/ext/erdtls/Makefile.am
@@ -19,8 +19,9 @@ libgsterdtls_la_CFLAGS = \
     $(OPENSSL_CFLAGS) \
     -DER_DTLS_USE_GST_LOG=1
 
-if !GST_PLUGIN_BUILD_STATIC
 libgsterdtls_la_LIBADD = $(GST_LIBS) $(GST_BASE_LIBS) $(OPENSSL_LIBS)
+libgsterdtls_la_LDFLAGS = $(GST_PLUGIN_LDFLAGS)
+if !GST_PLUGIN_BUILD_STATIC
 libgsterdtls_la_LIBTOOLFLAGS = --tag=disable-static
 endif
 

--- a/ext/openh264/src/Makefile.am
+++ b/ext/openh264/src/Makefile.am
@@ -11,8 +11,11 @@ libgstopenh264_la_SOURCES = \
 # compiler and linker flags used to compile this plugin, set in configure.ac
 libgstopenh264_la_CFLAGS = $(GST_CFLAGS) $(OPENH264_CFLAGS) -DGST_USE_UNSTABLE_API=1
 libgstopenh264_la_CXXFLAGS = $(GST_CFLAGS) $(OPENH264_CFLAGS) -DGST_USE_UNSTABLE_API=1
-libgstopenh264_la_LIBADD = $(GST_LIBS)
-libgstopenh264_la_LDFLAGS = $(GST_PLUGIN_LDFLAGS) $(OPENH264_LIBS)
+libgstopenh264_la_LIBADD = $(GST_LIBS) $(OPENH264_LIBS)
+libgstopenh264_la_LDFLAGS = $(GST_PLUGIN_LDFLAGS)
+if !GST_PLUGIN_BUILD_STATIC
+libgstopenh264_la_LIBTOOLFLAGS = --tag=disable-static
+endif
 
 
 -include $(top_srcdir)/git.mk

--- a/gst/ercolorspace/Makefile.am
+++ b/gst/ercolorspace/Makefile.am
@@ -9,9 +9,8 @@ libgstercolorspace_la_SOURCES += \
 endif
 
 libgstercolorspace_la_CFLAGS = $(GST_PLUGINS_BASE_CFLAGS) $(GST_BASE_CFLAGS) $(GST_CFLAGS)
+libgstercolorspace_la_LIBADD = $(GST_BASE_LIBS) $(GST_LIBS)
 libgstercolorspace_la_LDFLAGS = $(GST_PLUGIN_LDFLAGS)
-libgstercolorspace_la_LIBADD = \
-	$(GST_BASE_LIBS) $(GST_LIBS)
 if !GST_PLUGIN_BUILD_STATIC
 libgstercolorspace_la_LIBTOOLFLAGS = --tag=disable-static
 endif

--- a/gst/videorepair/Makefile.am
+++ b/gst/videorepair/Makefile.am
@@ -20,7 +20,9 @@ libgstvideorepair_la_SOURCES = gstvideorepair.c
 libgstvideorepair_la_CFLAGS = $(GST_CFLAGS) $(GST_PLUGINS_BASE_CFLAGS) -Wall -Wextra -Werror
 libgstvideorepair_la_LIBADD = $(GST_LIBS) -lgstvideo-1.0
 libgstvideorepair_la_LDFLAGS = $(GST_PLUGIN_LDFLAGS)
-#libgstvideorepair_la_LIBTOOLFLAGS = --tag=disable-static
+if !GST_PLUGIN_BUILD_STATIC
+libgstvideorepair_la_LIBTOOLFLAGS = --tag=disable-static
+endif
 
 # headers we need but don't want installed
 noinst_HEADERS = gstvideorepair.h

--- a/sys/androidvideo/video-source/Makefile.am
+++ b/sys/androidvideo/video-source/Makefile.am
@@ -10,9 +10,12 @@ libgstandroidvideosrc_la_SOURCES = \
 BUILT_SOURCES = \
     classes_dex.h
 
-libgstandroidvideosrc_la_LIBADD = -ldl -llog
-
-libgstandroidvideosrc_la_CFLAGS = -I$(srcdir)/jni
+libgstandroidvideosrc_la_LIBADD = $(GST_LIBS) $(GST_BASE_LIBS) -ldl -llog
+libgstandroidvideosrc_la_CFLAGS = $(GST_CFLAGS) $(GST_PLUGINS_BASE_CFLAGS) -I$(srcdir)/jni
+libgstandroidvideosrc_la_LDFLAGS = $(GST_PLUGIN_LDFLAGS)
+if !GST_PLUGIN_BUILD_STATIC
+libgstandroidvideosrc_la_LIBTOOLFLAGS = --tag=disable-static
+endif
 
 classes_dex.h: classes_dex.jar
 	$(XXD) -i $< > $@


### PR DESCRIPTION
We should use $(GST_PLUGIN_LDFLAGS) everywhere and also make sure
to pass all relevant libs and cflags and everything around.

Some libs might still be missing.

(As a side-effect: this creates a dynamic plugin for erdtls on OSX with the correct extension)
