### PR TITLE
androidvideo: target java VM 1.7

### DIFF
--- a/sys/androidvideo/video-source/Makefile.am
+++ b/sys/androidvideo/video-source/Makefile.am
@@ -25,6 +25,6 @@ classes_dex.jar: src/com/ericsson/gstreamer/VideoCaptureDevicePreviewCallbackHan
 
 %.class: %.java
 	test -d src || mkdir src
-	$(JAVAC) -classpath $(ANDROID_CLASSPATH) -d src $<
+	$(JAVAC) -source 1.7 -target 1.7 -classpath $(ANDROID_CLASSPATH) -d src $<
 
 -include $(top_srcdir)/git.mk


### PR DESCRIPTION
Fixes an error when building with a too recent jdk.

Verified on OS X with javac 1.7.0_67 