### PR TITLE
Build fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -79,17 +79,22 @@ if test "x$with_sctp" != "xyes"; then
   AC_MSG_ERROR([You need libusrsctp for the build])
 fi
 
-AC_CHECK_HEADERS([openssl/ssl.h],
-  [AC_CHECK_LIB([ssl], [SSL_library_init],
-    [with_openssl="yes"; OPENSSL_LIBS="-lssl"],
-    [with_openssl="no"]
-  )],[with_openssl="no"]
-)
-AC_SUBST(OPENSSL_LIBS)
-
-if test "x$with_openssl" != "xyes"; then
-  AC_MSG_ERROR([You need OpenSSL for the build])
+dnl check for openssl
+AC_MSG_CHECKING([whether to build erdtls])
+AC_ARG_ENABLE(
+  erdtls,
+  AC_HELP_STRING(
+    [--enable-erdtls],
+    [build erdtls plugin @<:@default=no@:>@]),
+  [AS_CASE(
+    [$enableval], [no], [], [yes], [],
+    [AC_MSG_ERROR([bad value "$enableval" for --enable-erdtls])])],
+  [enable_erdtls=no])
+AC_MSG_RESULT([$enable_erdtls])
+if test "x$enable_erdtls" = xyes; then
+  PKG_CHECK_MODULES(OPENSSL, [openssl])
 fi
+AM_CONDITIONAL(ERDTLS, test x$enable_erdtls = xyes)
 
 dnl build static plugins or not
 AC_MSG_CHECKING([whether to build static plugins or not])

--- a/configure.ac
+++ b/configure.ac
@@ -137,11 +137,21 @@ if test "x$enable_android_plugins" = xyes; then
   if test -z "$XXD"; then
     AC_MSG_ERROR([You need 'xxd' to build the Android plugins])
   fi
+
+  api_found=0
   dx_path=`AS_DIRNAME(["$DX"])`
-  ANDROID_CLASSPATH="$dx_path/../../platforms/android-19/android.jar"
-  if ! test -f "$ANDROID_CLASSPATH"; then
-    AC_MSG_ERROR([Android API level 19 not found in the SDK])
+  AC_MSG_CHECKING([which Android API Level to use])
+  for api_level in $(seq 9 22); do
+    ANDROID_CLASSPATH="$dx_path/../../platforms/android-$api_level/android.jar"
+    if test -f "$ANDROID_CLASSPATH"; then
+      api_found=$api_level
+      break
+    fi
+  done
+  if test "$api_found" = 0; then
+    AC_MSG_ERROR([No usable Android API levels not found in the SDK])
   fi
+  AC_MSG_RESULT([$api_found])
   AC_SUBST(ANDROID_CLASSPATH)
 fi
 AM_CONDITIONAL(BUILD_ANDROID_PLUGINS, test "x$enable_android_plugins" = "xyes")

--- a/ext/Makefile.am
+++ b/ext/Makefile.am
@@ -1,3 +1,10 @@
-SUBDIRS=erdtls sctp
-DIST_SUBDIRS = $(SUBDIRS) # needed since we are doing a out of tree build.
+SUBDIRS = sctp
+
+if ERDTLS
+SUBDIRS += erdtls
+endif
+
+# needed since we are doing a out of tree build.
+DIST_SUBDIRS = $(SUBDIRS)
+
 -include $(top_srcdir)/git.mk


### PR DESCRIPTION
Allows us to disable erdtls in Cerbero, and prefer using SDK version 20