### PR TITLE
gstsctpenc: Do not crash if caps are not provided when requesting pads

### DIFF
--- a/ext/sctp/gstsctpenc.c
+++ b/ext/sctp/gstsctpenc.c
@@ -818,6 +818,9 @@ static void get_config_from_caps(const GstCaps *caps, gboolean *ordered,
     *reliability_param = 0;
     *ppid_available = FALSE;
 
+    if (!caps)
+      return;
+
     n = gst_caps_get_size(caps);
     for (i = 0; i < n; i++) {
         s = gst_caps_get_structure(caps, i);


### PR DESCRIPTION
Some functions like gst_element_get_request_pad do not provide caps when
they are called on any GstElement to retrieve requested pads.