### PR TITLE
Fix Gstreamer warning and fix the usage of deprecated functions

### DIFF
--- a/ext/sctp/gstsctpenc.c
+++ b/ext/sctp/gstsctpenc.c
@@ -442,7 +442,11 @@ static void gst_sctp_enc_srcpad_loop(GstPad *pad)
 	}
 
         caps = gst_caps_new_empty_simple("application/x-sctp");
-        gst_pad_set_caps(self->src_pad, caps);
+        if (!gst_pad_push_event(self->src_pad, gst_event_new_caps (caps))) {
+	  GST_WARNING_OBJECT (self->src_pad, "Sending stream start event failed");
+	  gst_caps_unref(caps);
+	  return;
+	}
         gst_caps_unref(caps);
 
         self->need_stream_start_caps = FALSE;

--- a/ext/sctp/gstsctpenc.c
+++ b/ext/sctp/gstsctpenc.c
@@ -435,7 +435,11 @@ static void gst_sctp_enc_srcpad_loop(GstPad *pad)
         GstCaps *caps;
 
         g_snprintf(s_id, sizeof(s_id), "sctpenc-%08x", g_random_int());
-        gst_pad_push_event(self->src_pad, gst_event_new_stream_start(s_id));
+
+        if (!gst_pad_push_event(self->src_pad, gst_event_new_stream_start(s_id))) {
+	  GST_WARNING_OBJECT (self->src_pad, "Sending stream start event failed");
+	  return;
+	}
 
         caps = gst_caps_new_empty_simple("application/x-sctp");
         gst_pad_set_caps(self->src_pad, caps);


### PR DESCRIPTION
Afore mentioned warning can be observed when task function sends stream start events without being sucessful, it assumes that it already has sent the event and then starts sending data buffers. Next pipeline reproduces this case:

gst-launch sctpenc remote-sctp-port=5000 sctp-association-id=1 use-sock-stream=true ! dtlssrtpenc connection-id="c1" ! fakesink videotestsrc ! dtlssrtpdec connection-id="c1" ! sctpdec local-sctp-port=5000 sctp-association-id=1