### PR TITLE
sctp: Fix warnings setting callbacks when cleaning up the association

### DIFF
--- a/ext/sctp/gstsctpdec.c
+++ b/ext/sctp/gstsctpdec.c
@@ -581,7 +581,6 @@ static void stop_all_srcpad_tasks(GstSctpDec *self)
 static void sctpdec_cleanup(GstSctpDec *self)
 {
     if (self->sctp_association) {
-        gst_sctp_association_set_on_packet_received(self->sctp_association, NULL, NULL);
         g_signal_handler_disconnect(self->sctp_association, self->signal_handler_stream_reset);
         stop_all_srcpad_tasks(self);
         gst_sctp_association_force_close(self->sctp_association);

--- a/ext/sctp/gstsctpenc.c
+++ b/ext/sctp/gstsctpenc.c
@@ -782,7 +782,6 @@ static void sctpenc_cleanup(GstSctpEnc *self)
 {
     GstIterator *it;
 
-    gst_sctp_association_set_on_packet_out(self->sctp_association, NULL, NULL);
     g_signal_handler_disconnect(self->sctp_association, self->signal_handler_state_changed);
     stop_srcpad_task(self->src_pad, self);
     gst_sctp_association_force_close(self->sctp_association);


### PR DESCRIPTION
Do not set either packet or receive callbacks when cleaning up so theu can
only be set when state is GST_SCTP_ASSOCIATION_STATE_NEW.