### PR TITLE
sctpassociation: Fix GLib-GObject-WARNING **: invalid unclassed point…

### DIFF
--- a/ext/sctp/sctpassociation.c
+++ b/ext/sctp/sctpassociation.c
@@ -466,6 +466,7 @@ void gst_sctp_association_force_close(GstSctpAssociation *self)
 {
     g_mutex_lock(&self->association_mutex);
     if (self->sctp_ass_sock) {
+        usrsctp_shutdown (self->sctp_ass_sock, SHUT_RDWR);
         usrsctp_close(self->sctp_ass_sock);
         self->sctp_ass_sock = NULL;
     }


### PR DESCRIPTION
…er in cast to 'GstSctpAssociation'

Make the SCTP shutdown sequence before closing the socket allows sctp resources being released
when pipeline is set to NULL before any data has been sent through the pipeline.