### PR TITLE
sctp: export symbols with GST_EXPORT

### DIFF
--- a/gst-libs/gst/sctp/sctpreceivemeta.h
+++ b/gst-libs/gst/sctp/sctpreceivemeta.h
@@ -41,7 +41,11 @@ struct _GstSctpReceiveMeta {
 };
 
 GType gst_sctp_receive_meta_api_get_type(void);
+
+GST_EXPORT
 const GstMetaInfo * gst_sctp_receive_meta_get_info(void);
+
+GST_EXPORT
 GstSctpReceiveMeta * gst_sctp_buffer_add_receive_meta(GstBuffer *buffer, guint32 ppid);
 
 #define gst_sctp_buffer_get_receive_meta(b) ((GstSctpReceiveMeta *)gst_buffer_get_meta((b), GST_SCTP_RECEIVE_META_TYPE))

--- a/gst-libs/gst/sctp/sctpsendmeta.h
+++ b/gst-libs/gst/sctp/sctpsendmeta.h
@@ -52,7 +52,11 @@ struct _GstSctpSendMeta {
 };
 
 GType gst_sctp_send_meta_api_get_type(void);
+
+GST_EXPORT
 const GstMetaInfo * gst_sctp_send_meta_get_info(void);
+
+GST_EXPORT
 GstSctpSendMeta * gst_sctp_buffer_add_send_meta(GstBuffer *buffer, guint32 ppid, gboolean ordered,
     GstSctpSendMetaPartiallyReliability pr, guint32 pr_param);
 


### PR DESCRIPTION
It helps more explicit export.