### PR TITLE
sctp: Check if NULL before calling g_thread_join

### DIFF
--- a/ext/sctp/sctpassociation.c
+++ b/ext/sctp/sctpassociation.c
@@ -198,7 +198,10 @@ static void gst_sctp_association_finalize(GObject *object)
     }
     G_UNLOCK(associations_lock);
 
-    g_thread_join(self->connection_thread);
+    if (self->connection_thread != NULL) {
+      g_thread_join(self->connection_thread);
+      self->connection_thread = NULL;
+    }
 
     G_OBJECT_CLASS(gst_sctp_association_parent_class)->finalize(object);
 }

--- a/ext/sctp/sctpassociation.c
+++ b/ext/sctp/sctpassociation.c
@@ -203,6 +203,8 @@ static void gst_sctp_association_finalize(GObject *object)
       self->connection_thread = NULL;
     }
 
+    g_mutex_clear(&self->association_mutex);
+
     G_OBJECT_CLASS(gst_sctp_association_parent_class)->finalize(object);
 }
 


### PR DESCRIPTION
Otherwise, it complains by glib assertions if `conenction_thread` is NULL.