### PR TITLE
Fix state transition.

### DIFF
--- a/ext/sctp/gstsctpdec.c
+++ b/ext/sctp/gstsctpdec.c
@@ -259,17 +259,23 @@ static GstStateChangeReturn gst_sctp_dec_change_state(GstElement *element,
     switch (transition) {
     case GST_STATE_CHANGE_READY_TO_PAUSED:
         if (!configure_association(self))
-            ret = GST_STATE_CHANGE_FAILURE;
+            return GST_STATE_CHANGE_FAILURE;
         break;
+    default:
+        break;
+    }
+
+    ret = GST_ELEMENT_CLASS(parent_class)->change_state(element, transition);
+    if (ret == GST_STATE_CHANGE_FAILURE)
+      return ret;
+
+    switch (transition) {
     case GST_STATE_CHANGE_PAUSED_TO_READY:
         sctpdec_cleanup(self);
         break;
     default:
         break;
     }
-
-    if (ret != GST_STATE_CHANGE_FAILURE)
-        ret = GST_ELEMENT_CLASS(parent_class)->change_state(element, transition);
 
     return ret;
 }


### PR DESCRIPTION
State changes should be handled in two separate blocks with the downwards state
change handled only after we have chained up to the parent class's state change
function. This is necessary in order to safely handle concurrent access by
multiple threads.
More details here:
https://gstreamer.freedesktop.org/documentation/plugin-development/basics/states.html