### PR TITLE
Include inttypes.h for UINT16_MAX

### DIFF
--- a/ext/sctp/sctpassociation.c
+++ b/ext/sctp/sctpassociation.c
@@ -32,6 +32,7 @@
 #include <string.h>
 #include <errno.h>
 #include <stdlib.h>
+#include <inttypes.h>
 
 #define GST_SCTP_ASSOCIATION_STATE_TYPE (gst_sctp_association_state_get_type())
 static GType gst_sctp_association_state_get_type(void)


### PR DESCRIPTION
This fixes some build-breakage:
,----
| sctpassociation.c: In function ‘gst_sctp_association_init’:
| sctpassociation.c:84:22: error: ‘UINT16_MAX’ undeclared (first use in this function); did you mean ‘UINT_MAX’?
|  #define MAX_SCTP_SID UINT16_MAX
`----