### PR TITLE
sctpassociation: initialize sctp stack by atomic ref-count

### DIFF
--- a/ext/sctp/sctpassociation.c
+++ b/ext/sctp/sctpassociation.c
@@ -31,6 +31,7 @@
 
 #include <string.h>
 #include <errno.h>
+#include <stdint.h>
 #include <stdlib.h>
 
 #define GST_SCTP_ASSOCIATION_STATE_TYPE (gst_sctp_association_state_get_type())


### PR DESCRIPTION
Atomical reference count is introduced to prevent calling 'usrsctp_init()' while finalizing is on-going.

Also, 'usrsctp_finish()' is non-deterministic so it should be waiting for zero-return to be sure that sctp stack is torn down.