### PR TITLE
Add stdint header to support aarch64 compilation.

### DIFF
--- a/ext/sctp/sctpassociation.c
+++ b/ext/sctp/sctpassociation.c
@@ -32,6 +32,7 @@
 #include <string.h>
 #include <errno.h>
 #include <stdlib.h>
+#include <stdint.h>
 
 #define GST_SCTP_ASSOCIATION_STATE_TYPE (gst_sctp_association_state_get_type())
 static GType gst_sctp_association_state_get_type(void)


### PR DESCRIPTION
The compilation on an Nvidia Xavier failed because UINT16_MAX was not defined. Including the stdint header addresses that issue.